### PR TITLE
Fixed switch keyCode with shiftKey

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,11 +148,8 @@ export default class VirtualScroll {
             case keyCodes.DOWN:
                 evt.deltaY = -this.#options.keyStep
                 break
-            case keyCodes.SPACE && e.shiftKey:
-                evt.deltaY = windowHeight
-                break
             case keyCodes.SPACE:
-                evt.deltaY = -windowHeight
+                evt.deltaY = windowHeight * (e.shiftKey ? 1 : -1)
                 break
             default:
                 return


### PR DESCRIPTION
Ayo!

I was testing some accessibility stuff when using virtual-scroll on keydown and noticed shift + SPACE does not work as intended? Probably because `e.keyCode` !== `keyCodes.SPACE && e.shiftKey`?

I've updated the case when SPACE to use either 1 or -1 based on `e.shiftKey`, it seems to be working fine now.

🍻