### PR TITLE
Bug Fix - add missing parameter, remove extra parameter, address type issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import Emitter from 'tiny-emitter'
+import { Emitter } from 'tiny-emitter'
 import { getSupport } from './support'
 import { keyCodes } from './keycodes'
 
@@ -243,7 +243,7 @@ export default class VirtualScroll {
     }
 
     destroy() {
-        this.#emitter.off()
+        this.#emitter.off(EVT_ID)
         this._unbind()
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -236,7 +236,7 @@ export default class VirtualScroll {
     }
 
     off(cb, ctx) {
-        this.#emitter.off(EVT_ID, cb, ctx)
+        this.#emitter.off(EVT_ID, cb)
 
         var events = this.#emitter.e
         if (!events[EVT_ID] || events[EVT_ID].length <= 0) this._unbind()


### PR DESCRIPTION
- Add missing EVT_ID parameter in 'destroy' method.
- Change import to remove "This expression is not constructable. ts(2351)" error when Emitter is instanced with "new" on line 39.
- `tiny-emitter.off` does not accept a 'context' parameter. I've left the method signature alone for compatibility.